### PR TITLE
fix: change module name to allow go install to retrieve celestiaorg fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/testground/testground
+module github.com/celestiaorg/testground
 
 go 1.16
 


### PR DESCRIPTION
## Overview

This PR allows `go install github.com/celestiaorg/testground` to install successfully without encountering the following error:
```
 module declares its path as: github.com/testground/testground
                but was required as: github.com/celestiaorg/testground

```
