### PR TITLE
fix: add grace period 0 for pod deletion

### DIFF
--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -863,6 +863,11 @@ func (c *ClusterK8sRunner) createTestplanPod(ctx context.Context, podName string
 				"telegraf.influxdata.com/class":    "default",
 				"telegraf.influxdata.com/port":     "26660",
 				"telegraf.influxdata.com/interval": "10s",
+				"telegraf.influxdata.com/inputs": `|+ 
+							[[inputs.tail]] 
+								files = ["/var/log/**.out"]
+								data_format = "json"	
+				`,
 			},
 		},
 		Spec: v1.PodSpec{

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -865,7 +865,7 @@ func (c *ClusterK8sRunner) createTestplanPod(ctx context.Context, podName string
 				"telegraf.influxdata.com/interval": "10s",
 				"telegraf.influxdata.com/inputs": `|+ 
 							[[inputs.tail]] 
-								files = ["/var/log/**.out"]
+								files = ["/var/log/**.log"]
 								data_format = "json"	
 				`,
 			},

--- a/pkg/runner/cluster_k8s.go
+++ b/pkg/runner/cluster_k8s.go
@@ -338,8 +338,8 @@ func (c *ClusterK8sRunner) Run(ctx context.Context, input *api.RunInput, ow *rpc
 			}
 		}
 
+		var gracePeriod int64 = 0
 		for i := 0; i < g.Instances; i++ {
-			var gracePeriod int64 = 0
 			i := i
 			g := g
 			sem <- struct{}{}

--- a/pkg/sidecar/k8s_network.go
+++ b/pkg/sidecar/k8s_network.go
@@ -154,7 +154,7 @@ func (n *K8sNetwork) ConfigureNetwork(ctx context.Context, cfg *network.Config) 
 		delete(n.activeLinks, cfg.Network)
 	}
 
-	// Are we _connected_ to the network.
+	// Are we _connected_ to the network?
 	if !online {
 		// No, we're not.
 		// Connect.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
This PR is meant to fix 2 things

- [ ] pod deletion as soon as we finish the test run (grace period == 0) 
- [ ] forwarding logs to a file that telegraf input finds and stores into influxdb https://github.com/celestiaorg/testground-infra/pull/1

Latter will give us maximum assurance that all test data output is stored in a db without hassle of `kubectl logs pod` shenanigans i was doing here https://github.com/Bidon15/naive-logs-collector

In addition, it saves devs learning time. Meaning that they can `InfluxQL` metrics and logs 

Fixes https://github.com/celestiaorg/test-infra/issues/186
Fixes https://github.com/celestiaorg/test-infra/issues/117 
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
